### PR TITLE
Revert "Use native PHP incrementing operator"

### DIFF
--- a/LongPoller.php
+++ b/LongPoller.php
@@ -25,7 +25,7 @@ if (!$num) {
 }
 else {
 	//error_log("Num passed!");
-	$nextline = $num++;
+	$nextline = $num+1;
 	$safety_max = 130; // this is a number of seconds, it should be longer than the ajax timeout
 	sleep(2);
 	$cmd = "$sudo $wc -l $logfile | $cut -d \" \" -f 1 | $tr -d '\n' 2>/dev/null";


### PR DESCRIPTION
Reverts richardvk/web_file_tail#2 As per wdouglascampbell:
This change is incorrect. Instead of setting $nextline to $num + 1 (or the next line), it instead sets $nextline to $num and then increments the value of $num by 1.

This is indeed correct, thank you, reverting.